### PR TITLE
Fixed rspec path guessing to use binary provided by gem

### DIFF
--- a/lib/vagrant-rspec-ci/config.rb
+++ b/lib/vagrant-rspec-ci/config.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
         @tests = DEFAULT_TESTS if @tests == UNSET_VALUE
         
         if @rspec_bin_path == UNSET_VALUE then
-          guess = File.join(::Gem.bindir, 'rspec')
+          guess = ::Gem.bin_path 'rspec', 'rspec'
           @rspec_bin_path = File.exists?(guess) ? guess : DEFAULT_RSPEC_BIN_PATH
         end
       end


### PR DESCRIPTION
The new way will find the binary of the rspec gem installed to vagrants environment as dependency of the plugin. 
